### PR TITLE
Incrementing control is a valid UUIDv4

### DIFF
--- a/lib/identifier/uuid/controls/incrementing.rb
+++ b/lib/identifier/uuid/controls/incrementing.rb
@@ -8,15 +8,15 @@ module Identifier
 
           first_octet = (i).to_s.rjust(8, '0')
 
-          third_prefixes = ['8', '9', 'a', 'b']
+          fourth_prefixes = ['8', '9', 'a', 'b']
 
           if sample
-            third_prefix = third_prefixes.sample
+            fourth_prefix = fourth_prefixes.sample
           else
-            third_prefix = third_prefixes[0]
+            fourth_prefix = fourth_prefixes[0]
           end
 
-          "#{first_octet}-0000-4000-#{third_prefix}000-000000000000"
+          "#{first_octet}-0000-4000-#{fourth_prefix}000-000000000000"
         end
       end
     end

--- a/lib/identifier/uuid/controls/incrementing.rb
+++ b/lib/identifier/uuid/controls/incrementing.rb
@@ -16,7 +16,7 @@ module Identifier
             third_prefix = third_prefixes[0]
           end
 
-          "#{first_octet}-4000-#{third_prefix}000-0000-000000000000"
+          "#{first_octet}-0000-4000-#{third_prefix}000-000000000000"
         end
       end
     end

--- a/test/spec/control.rb
+++ b/test/spec/control.rb
@@ -1,0 +1,10 @@
+require_relative 'spec_init'
+
+describe "Controls" do
+  describe "Incrementing" do
+    specify "Is UUIDv4" do
+      uuid = Identifier::UUID::Controls::Incrementing.example
+      assert Identifier::UUID.uuid?(uuid)
+    end
+  end
+end


### PR DESCRIPTION
The previous implementation of `Identifier::UUID::Controls::Incrementing` was not generating valid v4 UUIDs. This control is used by the `controls` library, and is currently preventing me from being able to use `controls` in `account-interface` tests.

Wikipedia link: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
